### PR TITLE
Limiting backoffice access by user permissions & their jurisdiction

### DIFF
--- a/src/core/departments/routes.ts
+++ b/src/core/departments/routes.ts
@@ -1,10 +1,11 @@
 import { Request, Response, Router } from 'express';
 import { wrapHandler } from '../../helpers';
-import { resolveJurisdiction } from '../../middlewares';
+import { resolveJurisdiction, enforceJurisdictionAccess } from '../../middlewares';
 
 export const departmentRouter = Router();
 
 departmentRouter.use(wrapHandler(resolveJurisdiction()));
+departmentRouter.use(enforceJurisdictionAccess);
 
 departmentRouter.get('/', wrapHandler(async (req: Request, res: Response) => {
     const { Department } = res.app.repositories;

--- a/src/core/service-requests/routes.ts
+++ b/src/core/service-requests/routes.ts
@@ -1,6 +1,6 @@
 import { Request, Response, Router } from 'express';
 import { serviceRequestFiltersToSequelize, wrapHandler } from '../../helpers';
-import { resolveJurisdiction } from '../../middlewares';
+import { resolveJurisdiction, enforceJurisdictionAccess } from '../../middlewares';
 import { ServiceRequestAttributes } from '../../types';
 import { GovFlowEmitter } from '../event-listeners';
 import { SERVICE_REQUEST_CLOSED_STATES } from '../service-requests';
@@ -8,6 +8,7 @@ import { SERVICE_REQUEST_CLOSED_STATES } from '../service-requests';
 export const serviceRequestRouter = Router();
 
 serviceRequestRouter.use(wrapHandler(resolveJurisdiction()));
+serviceRequestRouter.use(enforceJurisdictionAccess);
 
 serviceRequestRouter.get('/status-list', wrapHandler(async (req: Request, res: Response) => {
     const { ServiceRequest } = res.app.repositories;

--- a/src/core/services/routes.ts
+++ b/src/core/services/routes.ts
@@ -1,12 +1,13 @@
 import merge from 'deepmerge';
 import { Request, Response, Router } from 'express';
 import { wrapHandler } from '../../helpers';
-import { resolveJurisdiction } from '../../middlewares';
+import { resolveJurisdiction, enforceJurisdictionAccess } from '../../middlewares';
 import { ServiceAttributes } from '../../types';
 
 export const serviceRouter = Router();
 
 serviceRouter.use(wrapHandler(resolveJurisdiction()));
+serviceRouter.use(enforceJurisdictionAccess);
 
 serviceRouter.get('/', wrapHandler(async (req: Request, res: Response) => {
     const { Service } = res.app.repositories;

--- a/src/core/staff-users/routes.ts
+++ b/src/core/staff-users/routes.ts
@@ -1,10 +1,11 @@
 import { Request, Response, Router } from 'express';
 import { wrapHandler } from '../../helpers';
-import { resolveJurisdiction } from '../../middlewares';
+import { resolveJurisdiction, enforceJurisdictionAccess } from '../../middlewares';
 
 export const accountRouter = Router();
 
 accountRouter.use(wrapHandler(resolveJurisdiction()));
+accountRouter.use(enforceJurisdictionAccess);
 
 accountRouter.get('/staff', wrapHandler(async (req: Request, res: Response) => {
     const { StaffUser } = res.app.repositories;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,10 @@ declare global {
         interface Request {
             jurisdiction: JurisdictionAttributes;
         }
+        interface User {
+            permissions: string[];
+            jurisdiction: string;
+        }
     }
 }
 /* eslint-enable */

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -61,3 +61,31 @@ export function resolveJurisdiction(paramKey = 'jurisdictionId', excludedRoutes:
         }
     }
 }
+
+export function enforceJurisdictionAccess(req: Request, res: Response, next: NextFunction): void {
+    const STATUS_CODE_UNAUTHORIZED = 401;
+    const STATUS_CODE_FORBIDDEN = 403;
+
+    if (!process.env.ENFORCE_AUTHORIZATION) {
+        // TODO remove once we support auth on Govflow and adapt tests to make requests as authenticated users
+        next();
+        return;
+    }
+
+    if (!req.user) {
+        res.status(STATUS_CODE_UNAUTHORIZED).send();
+        return;
+    }
+
+    if (req.user.permissions?.includes('access-all-jurisdictions')) {
+        next();
+        return;
+    }
+
+    if (req.user.jurisdiction === req.jurisdiction.id) {
+        next();
+        return;
+    }
+
+    res.status(STATUS_CODE_FORBIDDEN).send();
+}


### PR DESCRIPTION
Closes #42 

As authentication is not currently done on Govflow, this is not covered in tests; the policy is skipped unless you turn on the ENFORCE_AUTHORIZATION environment variable.

Once we have auth, API tests should run using a logged in user, and a test should be added to verify 401/403 is returned for unauthenticated/unauthorized users