### PR TITLE
Feature/readable ticket

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "generate-fake-data": "ts-node ./src/cli/generate-fake-data",
     "send-test-email": "ts-node ./src/cli/send-test-email",
     "send-test-sms": "ts-node ./src/cli/send-test-sms",
-    "send-test-dispatch": "ts-node ./src/cli/send-test-dispatch"
+    "send-test-dispatch": "ts-node ./src/cli/send-test-dispatch",
+    "ensure-public-ids": "ts-node ./src/cli/ensure-public-ids"
   },
   "bin": {
     "govflow-start": "./cli/default-server.js",
@@ -21,7 +22,8 @@
     "govflow-generate-fake-data": "./cli/generate-fake-data.js",
     "govflow-send-test-email": "./cli/send-test-email.js",
     "govflow-send-test-sms": "./cli/send-test-sms.js",
-    "govflow-send-test-dispatch": "./cli/send-test-dispatch.js"
+    "govflow-send-test-dispatch": "./cli/send-test-dispatch.js",
+    "govflow-ensure-public-ids": "./cli/ensure-public-ids.js"
   },
   "license": "MIT",
   "dependencies": {

--- a/src/cli/ensure-public-ids.ts
+++ b/src/cli/ensure-public-ids.ts
@@ -1,0 +1,12 @@
+#! /usr/bin/env node
+import { createApp } from '..';
+
+(async () => {
+    const app = await createApp();
+    const { database } = app;
+    const { ServiceRequest } = database.models;
+    const records = await ServiceRequest.findAll();
+    for (const record of records) {
+        await record.save()
+    }
+})();

--- a/src/core/service-requests/helpers.ts
+++ b/src/core/service-requests/helpers.ts
@@ -1,4 +1,5 @@
-import { StaffUserAttributes } from "../../types";
+import { Op } from "sequelize";
+import { ServiceRequestInstance, StaffUserAttributes } from "../../types";
 
 export function makeAuditMessage(user: StaffUserAttributes | undefined, fieldName: string, oldValue:string, newValue:string): string {
     let displayName = 'System';
@@ -8,7 +9,34 @@ export function makeAuditMessage(user: StaffUserAttributes | undefined, fieldNam
     return `${displayName} changed this request ${fieldName} from ${oldValue} to ${newValue}`;
 }
 
-export function makePublicIdForRequest(): string {
+export async function makePublicIdForRequest(instance: ServiceRequestInstance): Promise<void> {
+    const _year = instance.createdAt.getFullYear();
+    const _month = instance.createdAt.getMonth();
+    const windowLower = new Date(_year, _month, 0);
+    const windowHigher =  (_month != 11) ? new Date(_year, _month + 1, 0) : new Date(_year + 1, 0, 0)
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    const lookup = await instance.constructor.findAll(
+        {
+            where: {
+                jurisdictionId: instance.jurisdictionId,
+                createdAt: { [Op.gte]: windowLower, [Op.lt]: windowHigher }
+            }
+        }
+    ) as ServiceRequestInstance[];
+    let lastIncrement = 0;
+    if (lookup.length > 0) {
+        const lastRecord = lookup.reduce(
+            (last: ServiceRequestInstance, curr: ServiceRequestInstance) =>
+            (last.idCounter > curr.idCounter) ? last : curr
 
-    return ""
+        );
+        lastIncrement = lastRecord.idCounter;
+    }
+    const year = _year.toString(10).slice(-2);
+    const month = String((_month + 1).toString(10)).padStart(2, "0");
+    const idCounter = lastIncrement + 1;
+    const publicId = `${year}::${month}::${idCounter}`
+    instance.idCounter = idCounter;
+    instance.publicId = publicId;
 }

--- a/src/core/service-requests/helpers.ts
+++ b/src/core/service-requests/helpers.ts
@@ -7,3 +7,8 @@ export function makeAuditMessage(user: StaffUserAttributes | undefined, fieldNam
     }
     return `${displayName} changed this request ${fieldName} from ${oldValue} to ${newValue}`;
 }
+
+export function makePublicIdForRequest(): string {
+
+    return ""
+}

--- a/src/core/service-requests/models.ts
+++ b/src/core/service-requests/models.ts
@@ -1,5 +1,6 @@
 import { DataTypes } from 'sequelize';
 import { ModelDefinition } from '../../types';
+import { makePublicIdForRequest } from './helpers';
 
 export const REQUEST_STATUSES = {
     'inbox': 'Inbox',
@@ -38,6 +39,11 @@ export const ServiceRequestModel: ModelDefinition = {
             defaultValue: DataTypes.UUIDV4,
             allowNull: false,
             primaryKey: true,
+        },
+        publicId: {
+            type: DataTypes.STRING,
+            defaultValue: makePublicIdForRequest,
+            allowNull: false,
         },
         inputChannel: {
             allowNull: false,
@@ -171,6 +177,10 @@ export const ServiceRequestModel: ModelDefinition = {
             {
                 unique: true,
                 fields: ['id', 'jurisdictionId']
+            },
+            {
+                unique: true,
+                fields: ['publicId', 'jurisdictionId']
             },
             {
                 unique: false,

--- a/src/core/service-requests/models.ts
+++ b/src/core/service-requests/models.ts
@@ -1,5 +1,5 @@
 import { DataTypes } from 'sequelize';
-import { ModelDefinition } from '../../types';
+import { ModelDefinition, ServiceRequestInstance } from '../../types';
 import { makePublicIdForRequest } from './helpers';
 
 export const REQUEST_STATUSES = {
@@ -42,7 +42,10 @@ export const ServiceRequestModel: ModelDefinition = {
         },
         publicId: {
             type: DataTypes.STRING,
-            defaultValue: makePublicIdForRequest,
+            allowNull: false,
+        },
+        idCounter: {
+            type: DataTypes.INTEGER,
             allowNull: false,
         },
         inputChannel: {
@@ -204,6 +207,11 @@ export const ServiceRequestModel: ModelDefinition = {
                 if ((this.lat || this.lon === null) && (this.address === null) && (this.address_id === null)) {
                     throw new Error('A Service Request requires one of a lat/lon pair, address, or address_id.');
                 }
+            }
+        },
+        hooks: {
+            beforeValidate(instance: ServiceRequestInstance) {
+                return makePublicIdForRequest(instance);
             }
         }
     }

--- a/src/core/service-requests/repositories.ts
+++ b/src/core/service-requests/repositories.ts
@@ -138,8 +138,6 @@ export class ServiceRequestRepository implements IServiceRequestRepository {
     ): Promise<ServiceRequestAttributes> {
         const { ServiceRequest } = this.models;
         let record = await ServiceRequest.findByPk(id) as ServiceRequestInstance;
-        console.error("ASSIGNED TO")
-        console.error(user);
         const auditMessage = makeAuditMessage(user, '"assigned to"', record.assignedTo, assignedTo);
         record.assignedTo = assignedTo;
         record = await record.save();
@@ -152,8 +150,6 @@ export class ServiceRequestRepository implements IServiceRequestRepository {
     ): Promise<ServiceRequestAttributes> {
         const { ServiceRequest } = this.models;
         let record = await ServiceRequest.findByPk(id) as ServiceRequestInstance;
-        console.error("DEPARTMENT")
-        console.error(user);
         const auditMessage = makeAuditMessage(user, '"department"', record.departmentId, department);
         record.departmentId = department;
         record = await record.save();

--- a/src/migrations/11_public_id_for_request.ts
+++ b/src/migrations/11_public_id_for_request.ts
@@ -1,17 +1,22 @@
 import type { QueryInterface } from 'sequelize';
 import { DataTypes } from 'sequelize';
-import { makePublicIdForRequest } from '../core/service-requests/helpers';
 
 export async function up({ context: queryInterface }: Record<string, QueryInterface>): Promise<void> {
     await queryInterface.addColumn(
         'ServiceRequest',
         'publicId',
-        { type: DataTypes.STRING,defaultValue: makePublicIdForRequest, allowNull: false }
+        { type: DataTypes.STRING, allowNull: false }
+    );
+    await queryInterface.addColumn(
+        'ServiceRequest',
+        'idCounter',
+        { type: DataTypes.INTEGER, allowNull: false }
     );
     await queryInterface.addIndex('ServiceRequest', ['jurisdictionId', 'publicId']);
 }
 
 export async function down({ context: queryInterface }: Record<string, QueryInterface>): Promise<void> {
     await queryInterface.removeColumn('ServiceRequest', 'publicId');
+    await queryInterface.removeColumn('ServiceRequest', 'idCounter');
     await queryInterface.removeIndex('ServiceRequest', ['jurisdictionId', 'publicId'])
 }

--- a/src/migrations/11_public_id_for_request.ts
+++ b/src/migrations/11_public_id_for_request.ts
@@ -1,0 +1,17 @@
+import type { QueryInterface } from 'sequelize';
+import { DataTypes } from 'sequelize';
+import { makePublicIdForRequest } from '../core/service-requests/helpers';
+
+export async function up({ context: queryInterface }: Record<string, QueryInterface>): Promise<void> {
+    await queryInterface.addColumn(
+        'ServiceRequest',
+        'publicId',
+        { type: DataTypes.STRING,defaultValue: makePublicIdForRequest, allowNull: false }
+    );
+    await queryInterface.addIndex('ServiceRequest', ['jurisdictionId', 'publicId']);
+}
+
+export async function down({ context: queryInterface }: Record<string, QueryInterface>): Promise<void> {
+    await queryInterface.removeColumn('ServiceRequest', 'publicId');
+    await queryInterface.removeIndex('ServiceRequest', ['jurisdictionId', 'publicId'])
+}

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -49,6 +49,8 @@ export interface ServiceInstance
 
 export interface ServiceRequestAttributes {
     id: string;
+    publicId: string,
+    idCounter: number,
     serviceId?: string;
     jurisdictionId: string;
     description: string;

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -31,11 +31,13 @@ export interface ServiceRequestFilterParams {
     assignedTo?: string;
 }
 
+export type  ServiceRequestModel = ModelCtor<Model<ServiceRequestAttributes, ServiceRequestCreateAttributes>>;
+
 export interface Models {
     Jurisdiction: ModelCtor<Model<JurisdictionAttributes, JurisdictionCreateAttributes>>,
     StaffUser: ModelCtor<Model<StaffUserAttributes, StaffUserCreateAttributes>>,
     Service: ModelCtor<Model<ServiceAttributes, ServiceCreateAttributes>>,
-    ServiceRequest: ModelCtor<Model<ServiceRequestAttributes, ServiceRequestCreateAttributes>>,
+    ServiceRequest: ServiceRequestModel,
     ServiceRequestComment: ModelCtor<Model<ServiceRequestCommentAttributes, ServiceRequestCommentCreateAttributes>>,
     Communication: ModelCtor<Model<CommunicationAttributes, CommunicationCreateAttributes>>,
     Department: ModelCtor<Model<DepartmentAttributes, DepartmentCreateAttributes>>,

--- a/test/test-models.ts
+++ b/test/test-models.ts
@@ -2,7 +2,7 @@ import chai from 'chai';
 import type { Application } from 'express';
 import { createApp } from '../src/index';
 import makeTestData from '../src/tools/fake-data-generator';
-import { TestDataPayload } from '../src/types';
+import { ServiceRequestInstance, TestDataPayload } from '../src/types';
 
 describe('Verify Core Models.', function () {
 
@@ -57,6 +57,16 @@ describe('Verify Core Models.', function () {
         for (const serviceRequestData of testData.serviceRequests) {
             const record = await ServiceRequest.create(serviceRequestData);
             chai.assert(record);
+        }
+    });
+
+    it('should have generated public ids for service requests', async function () {
+        const { ServiceRequest } = app.database.models;
+        const records = await ServiceRequest.findAll() as ServiceRequestInstance[];
+
+        for (const record of records) {
+            chai.assert(record.publicId);
+            chai.assert(record.idCounter);
         }
     });
 


### PR DESCRIPTION
@amirozer 


This is ready for review.

There is a task that can be run to ensure public ids on existing databases, instead of adding it as a data migration - more flexible and easier with how data migrations work in Sequelize. 