### PR TITLE
Feature/communication status email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.41-alpha",
       "license": "MIT",
       "dependencies": {
+        "@sendgrid/eventwebhook": "^7.4.5",
         "@sendgrid/mail": "^7.6.0",
         "@types/nodemailer": "^6.4.4",
         "axios": "^0.24.0",
@@ -877,6 +878,17 @@
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
         "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/@sendgrid/eventwebhook": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@sendgrid/eventwebhook/-/eventwebhook-7.4.5.tgz",
+      "integrity": "sha512-A/J/D0F5LAuFNkFMhOeshOHY6RCetgkvPxHEqMtB5861wwT9H1PNIsrk0ykXNmNX2f2GGJAoFFLP/7KlfLu5Hg==",
+      "dependencies": {
+        "starkbank-ecdsa": "^1.1.1"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >=10.*"
       }
     },
     "node_modules/@sendgrid/helpers": {
@@ -1769,6 +1781,14 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/binary-extensions": {
@@ -3601,9 +3621,9 @@
       }
     },
     "node_modules/gauge/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "engines": {
         "node": ">=4"
       }
@@ -4545,6 +4565,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4985,9 +5010,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minio": {
       "version": "7.0.25",
@@ -6766,6 +6791,15 @@
         "node": "*"
       }
     },
+    "node_modules/starkbank-ecdsa": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/starkbank-ecdsa/-/starkbank-ecdsa-1.1.4.tgz",
+      "integrity": "sha512-0qmTALYdUMS34tuGqZEKFRY3psx4mh0g8AjevytRQFuZp64V2PYG3ncc0y2mxoISSW7qvtztsa1rgRLszrRGkw==",
+      "dependencies": {
+        "big-integer": "^1.6.48",
+        "js-sha256": "^0.9.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -8400,6 +8434,14 @@
         }
       }
     },
+    "@sendgrid/eventwebhook": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@sendgrid/eventwebhook/-/eventwebhook-7.4.5.tgz",
+      "integrity": "sha512-A/J/D0F5LAuFNkFMhOeshOHY6RCetgkvPxHEqMtB5861wwT9H1PNIsrk0ykXNmNX2f2GGJAoFFLP/7KlfLu5Hg==",
+      "requires": {
+        "starkbank-ecdsa": "^1.1.1"
+      }
+    },
     "@sendgrid/helpers": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.6.0.tgz",
@@ -9102,6 +9144,11 @@
         "@mapbox/node-pre-gyp": "^1.0.0",
         "node-addon-api": "^3.1.0"
       }
+    },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -10571,9 +10618,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -11232,6 +11279,11 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11592,9 +11644,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minio": {
       "version": "7.0.25",
@@ -12925,6 +12977,15 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "starkbank-ecdsa": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/starkbank-ecdsa/-/starkbank-ecdsa-1.1.4.tgz",
+      "integrity": "sha512-0qmTALYdUMS34tuGqZEKFRY3psx4mh0g8AjevytRQFuZp64V2PYG3ncc0y2mxoISSW7qvtztsa1rgRLszrRGkw==",
+      "requires": {
+        "big-integer": "^1.6.48",
+        "js-sha256": "^0.9.0"
+      }
     },
     "statuses": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@sendgrid/eventwebhook": "^7.4.5",
     "@sendgrid/mail": "^7.6.0",
     "@types/nodemailer": "^6.4.4",
     "axios": "^0.24.0",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -18,6 +18,7 @@ const defaultSettings: AppSettings = {
     'databaseExtraMigrationPaths': '',
     'sendGridApiKey': process.env.SENDGRID_API_KEY || '',
     'sendGridFromEmail': process.env.SENDGRID_FROM_EMAIL || '',
+    'sendGridSignedWebhookVerificationKey': process.env.SENDGRID_SIGNED_WEBHOOK_VERIFICATION_KEY || '',
     'twilioAccountSid': process.env.TWILIO_ACCOUNT_SID || '',
     'twilioAuthToken': process.env.TWILIO_AUTH_TOKEN || '',
     'twilioFromPhone': process.env.TWILIO_FROM_PHONE || '',

--- a/src/core/communications/helpers.ts
+++ b/src/core/communications/helpers.ts
@@ -61,7 +61,9 @@ export async function dispatchMessageForPublicUser(
         logger.warn(`Cannot send message for ${serviceRequest.id} as no communication address is valid.`);
         return {} as CommunicationAttributes;
     } else {
-        const record = await dispatchMessage(dispatchConfig, templateConfig, CommunicationRepository, EmailStatusRepository);
+        const record = await dispatchMessage(
+            dispatchConfig, templateConfig, CommunicationRepository, EmailStatusRepository
+        );
         if (record.accepted === true) {
             serviceRequest.communicationValid = true
         } else {

--- a/src/core/communications/helpers.ts
+++ b/src/core/communications/helpers.ts
@@ -1,3 +1,4 @@
+import { EventWebhook } from '@sendgrid/eventwebhook';
 import type { ClientResponse } from '@sendgrid/mail';
 import addrs from 'email-addresses';
 import { constants as fsConstants, promises as fs } from 'fs';
@@ -7,7 +8,7 @@ import striptags from 'striptags';
 import { sendEmail } from '../../email';
 import logger from '../../logging';
 import { sendSms } from '../../sms';
-import { CommunicationAttributes, DispatchConfigAttributes, DispatchPayloadAttributes, ICommunicationRepository, IEmailStatusRepository, InboundEmailDataToRequestAttributes, InboundMapInstance, InboundMapModel, ParsedServiceRequestAttributes, PublicId, ServiceRequestAttributes, TemplateConfigAttributes, TemplateConfigContextAttributes } from '../../types';
+import { CommunicationAttributes, DispatchConfigAttributes, DispatchPayloadAttributes, EmailEventAttributes, ICommunicationRepository, IEmailStatusRepository, InboundEmailDataToRequestAttributes, InboundMapInstance, InboundMapModel, ParsedServiceRequestAttributes, PublicId, ServiceRequestAttributes, TemplateConfigAttributes, TemplateConfigContextAttributes } from '../../types';
 
 export const publicIdSubjectLinePattern = /Request #(\d+):/;
 
@@ -264,4 +265,14 @@ export function canSubmitterComment(submitterEmail: string, validEmails: string[
     } else {
         return false;
     }
+}
+
+export function verifySendGridWebhook(
+    publicKey: string, payload: EmailEventAttributes, signature: string | undefined, timestamp: string | undefined
+): boolean {
+    const ew = new EventWebhook();
+    const key = ew.convertPublicKeyToECDSA(publicKey);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    return ew.verifySignature(key, payload, signature, timestamp);
 }

--- a/src/core/communications/helpers.ts
+++ b/src/core/communications/helpers.ts
@@ -102,7 +102,7 @@ export async function dispatchMessage(
         // Because we cant control how the various APIs are used and interact,
         // We are doing a check here at the last step before actually sending
         const emailStatus = await EmailStatusRepository.findOne(dispatchConfig.toEmail);
-        if (emailStatus && emailStatus.status === false) {
+        if (emailStatus && emailStatus.isAllowed === false) {
             const errorMsg = `${dispatchConfig.toEmail} is not allowed for communications.`;
             logger.error(errorMsg);
             throw new Error(errorMsg);

--- a/src/core/communications/models.ts
+++ b/src/core/communications/models.ts
@@ -129,11 +129,11 @@ export const ChannelStatusModel: ModelDefinition = {
             allowNull: false,
             type: DataTypes.ENUM('email', 'phone'),
         },
-        status: {
+        isAllowed: {
             type: DataTypes.BOOLEAN,
             allowNull: true,
         },
-        statusLog: { // an array of [event, status] ordered new to old
+        log: { // an array of [event, status] ordered new to old
             type: DataTypes.JSONB,
             allowNull: false,
         },

--- a/src/core/communications/models.ts
+++ b/src/core/communications/models.ts
@@ -1,5 +1,25 @@
 import { DataTypes } from 'sequelize';
+import validator from 'validator';
 import type { ModelDefinition } from '../../types';
+
+export const EMAIL_EVENT_MAP = {
+    'processed': null, // Message has been received and is ready to be delivered.
+    'deferred': null, // Receiving server temporarily rejected the message.
+    'delivered': true, // Message has been successfully delivered to the receiving server.
+    'bounce': false, // Receiving server could not or would not accept mail to this recipient permanently. If a recipient has previously unsubscribed from your emails, the message is dropped.
+    'blocked': false, // Receiving server could not or would not accept the message temporarily. If a recipient has previously unsubscribed from your emails, the message is dropped.
+    'dropped': false, // You may see the following drop reasons: Invalid SMTPAPI header, Spam Content (if Spam Checker app is enabled), Unsubscribed Address, Bounced Address, Spam Reporting Address, Invalid, Recipient List over Package Quota
+    'spamreport': false, // Recipient marked message as spam.
+    'unsubscribe': false, // Recipient clicked on the 'Opt Out of All Emails' link (available after clicking the message's subscription management link). Subscription Tracking needs to be enabled for this type of event.
+    'group_unsubscribe': false, // Recipient unsubscribed from a specific group either by clicking the link directly or updating their preferences. Subscription Tracking needs to be enabled for this type of event.
+    'group_resubscribe': true, // Recipient resubscribed to a specific group by updating their preferences. Subscription Tracking needs to be enabled for this type of event.
+    'open': null, // Recipient has opened the HTML message. Open Tracking needs to be enabled for this type of event.
+    'click': null, // Recipient clicked on a link within the message. Click Tracking needs to be enabled for this type of event.
+} as Record<string, boolean | null>;
+
+export const EMAIL_EVENT_IGNORE = ['processed', 'deferred', 'open', 'clicked']
+
+export const EMAIL_EVENT_MAP_KEYS = Object.keys(EMAIL_EVENT_MAP);
 
 export const CommunicationModel: ModelDefinition = {
     name: 'Communication',
@@ -95,5 +115,53 @@ export const InboundMapModel: ModelDefinition = {
                 fields: ['id', 'jurisdictionId', 'departmentId']
             }
         ]
+    }
+}
+
+export const ChannelStatusModel: ModelDefinition = {
+    name: 'ChannelStatus',
+    attributes: {
+        id: { // email or phone
+            type: DataTypes.STRING,
+            primaryKey: true,
+        },
+        channel: {
+            allowNull: false,
+            type: DataTypes.ENUM('email', 'phone'),
+        },
+        status: {
+            type: DataTypes.BOOLEAN,
+            allowNull: true,
+        },
+        statusLog: { // an array of [event, status] ordered new to old
+            type: DataTypes.JSONB,
+            allowNull: false,
+        },
+    },
+    options: {
+        freezeTableName: true,
+        indexes: [
+            {
+                unique: true,
+                fields: ['id', 'channel']
+            },
+            {
+                unique: false,
+                fields: ['channel']
+            }
+        ],
+        validate: {
+            oneOfEmailOrPhone() {
+                if (this.channel === 'email') {
+                    try {
+                        validator.isEmail(this.id as string);
+                    } catch {
+                        throw new Error(`${this.id} is not a validate email.`);
+                    }
+                } else if (this.channel === 'phone') {
+                    // TODO: validate phone when we can
+                }
+            }
+        }
     }
 }

--- a/src/core/communications/repositories.ts
+++ b/src/core/communications/repositories.ts
@@ -12,12 +12,11 @@ import type {
     IInboundEmailRepository,
     InboundEmailDataAttributes,
     InboundMapAttributes,
-    InboundMapInstance,
-    Models,
+    InboundMapInstance, LogEntry, Models,
     ServiceRequestAttributes,
     ServiceRequestCommentAttributes,
     ServiceRequestCommentInstance,
-    ServiceRequestInstance, StaffUserInstance, StatusLogEntry
+    ServiceRequestInstance, StaffUserInstance
 } from '../../types';
 import { canSubmitterComment, extractServiceRequestfromInboundEmail } from './helpers';
 import { EMAIL_EVENT_MAP } from './models';
@@ -130,18 +129,18 @@ export class EmailStatusRepository implements IEmailStatusRepository {
         if (event === 'bounced') {
             eventKey = type as string;
         }
-        const status = EMAIL_EVENT_MAP[eventKey];
-        const statusLogEntry = [eventKey, EMAIL_EVENT_MAP[eventKey]] as StatusLogEntry;
+        const isAllowed = EMAIL_EVENT_MAP[eventKey];
+        const logEntry = [eventKey, EMAIL_EVENT_MAP[eventKey]] as LogEntry;
         const exists = await ChannelStatus.findOne({ where: { id: email } }) as ChannelStatusInstance;
         let record;
         if (exists) {
-            exists.status = status
-            exists.statusLog.unshift(statusLogEntry)
+            exists.isAllowed = isAllowed
+            exists.log.unshift(logEntry)
             record = exists.save()
         } else {
-            const statusLog = [statusLogEntry];
+            const log = [logEntry];
             record = await ChannelStatus.create(
-                { id: email, channel: 'email', status, statusLog }
+                { id: email, channel: 'email', isAllowed, log }
             ) as ChannelStatusInstance;
         }
         return record;

--- a/src/core/communications/repositories.ts
+++ b/src/core/communications/repositories.ts
@@ -120,7 +120,7 @@ export class EmailStatusRepository implements IEmailStatusRepository {
 
     async create(data: ChannelStatusCreateAttributes): Promise<ChannelStatusInstance> {
         const { ChannelStatus } = this.models;
-        return await ChannelStatus.create(data) as ChannelStatusInstance;;
+        return await ChannelStatus.create(data) as ChannelStatusInstance;
     }
 
     async createFromEvent(data: EmailEventAttributes): Promise<ChannelStatusInstance> {

--- a/src/core/communications/routes.ts
+++ b/src/core/communications/routes.ts
@@ -2,9 +2,44 @@ import { Request, Response, Router } from 'express';
 import multer from 'multer';
 import { wrapHandler } from '../../helpers';
 import { enforceJurisdictionAccess, resolveJurisdiction } from '../../middlewares';
+import { EmailEventAttributes } from '../../types';
 import { GovFlowEmitter } from '../event-listeners';
+import { EMAIL_EVENT_IGNORE } from './models';
 
 export const communicationsRouter = Router();
+
+// public route for web hook integration
+communicationsRouter.post('/inbound/email', multer().none(), wrapHandler(async (req: Request, res: Response) => {
+    const { InboundEmail } = res.app.repositories;
+    const { Communication: dispatchHandler } = res.app.services;
+    const record = await InboundEmail.createServiceRequest(req.body);
+    GovFlowEmitter.emit('serviceRequestCreate', req.jurisdiction, record, dispatchHandler);
+    res.status(200).send({ data: { status: 200, message: "Received inbound email" } });
+}))
+
+// public route for web hook integration
+communicationsRouter.post('/events/email', wrapHandler(async (req: Request, res: Response) => {
+    const { EmailStatus } = res.app.repositories;
+    const emailEvents = req.body as unknown as EmailEventAttributes[];
+    for (const event of emailEvents) {
+        if (!EMAIL_EVENT_IGNORE.includes(event.event)) { await EmailStatus.createFromEvent(event); }
+    }
+    res.status(200).send({ data: { status: 200, message: "Received email event" } });
+}))
+
+communicationsRouter.get('/status/email/:email',
+    wrapHandler(resolveJurisdiction()),
+    enforceJurisdictionAccess,
+    wrapHandler(async (req: Request, res: Response) => {
+        const { EmailStatus } = res.app.repositories;
+        // We enforce jurisdiction access for security, but actually
+        // our email delivery status is global, not by jurisdiction
+        // So the jurisdiction is not used in the data query.
+        const base64Email = req.params.email;
+        const email = Buffer.from(base64Email, 'base64url').toString('ascii');
+        const record = await EmailStatus.findOne(email);
+        res.status(200).send({ data: record });
+    }))
 
 communicationsRouter.post('/create-map',
     wrapHandler(resolveJurisdiction()),
@@ -15,11 +50,3 @@ communicationsRouter.post('/create-map',
         const record = await InboundEmail.createMap(data);
         res.status(200).send({ data: record });
     }))
-
-communicationsRouter.post('/inbound/email', multer().none(), wrapHandler(async (req: Request, res: Response) => {
-    const { InboundEmail } = res.app.repositories;
-    const { Communication: dispatchHandler } = res.app.services;
-    const record = await InboundEmail.createServiceRequest(req.body);
-    GovFlowEmitter.emit('serviceRequestCreate', req.jurisdiction, record, dispatchHandler);
-    res.status(200).send({ data: { status: 200, message: "Received inbound email" } });
-}))

--- a/src/core/communications/services.ts
+++ b/src/core/communications/services.ts
@@ -255,7 +255,9 @@ export class CommunicationService implements ICommunicationService {
                     recipientName: admin.displayName as string
                 }
             }
-            const record = await dispatchMessageForStaffUser(dispatchConfig, templateConfig, Communication, EmailStatus);
+            const record = await dispatchMessageForStaffUser(
+                dispatchConfig, templateConfig, Communication, EmailStatus
+            );
             records.push(record);
         }
         return records;

--- a/src/core/communications/services.ts
+++ b/src/core/communications/services.ts
@@ -21,8 +21,8 @@ export class CommunicationService implements ICommunicationService {
     constructor(
         @inject(appIds.Repositories) repositories: Repositories,
         @inject(appIds.AppSettings) settings: AppSettings,) {
-            this.repositories = repositories;
-            this.settings = settings;
+        this.repositories = repositories;
+        this.settings = settings;
     }
 
     async dispatchServiceRequestCreate(
@@ -40,7 +40,7 @@ export class CommunicationService implements ICommunicationService {
             twilioFromPhone
         } = this.settings;
 
-        const { Communication, StaffUser } = this.repositories;
+        const { Communication, StaffUser, EmailStatus } = this.repositories;
 
         const records: CommunicationAttributes[] = [];
 
@@ -66,7 +66,7 @@ export class CommunicationService implements ICommunicationService {
             }
         }
         const record = await dispatchMessageForPublicUser(
-            serviceRequest, dispatchConfig, templateConfig, Communication
+            serviceRequest, dispatchConfig, templateConfig, Communication, EmailStatus
         );
         records.push(record);
         const [staffUsers, _count] = await StaffUser.findAll(serviceRequest.jurisdictionId);
@@ -94,7 +94,7 @@ export class CommunicationService implements ICommunicationService {
                 }
             }
             const record = await dispatchMessageForStaffUser(
-                dispatchConfig, templateConfig, Communication
+                dispatchConfig, templateConfig, Communication, EmailStatus
             );
             records.push(record);
         }
@@ -115,7 +115,7 @@ export class CommunicationService implements ICommunicationService {
             twilioAuthToken,
             twilioFromPhone
         } = this.settings;
-        const { StaffUser, Communication } = this.repositories;
+        const { StaffUser, Communication, EmailStatus } = this.repositories;
         const staffUser = await StaffUser.findOne(
             serviceRequest.jurisdictionId, serviceRequest.assignedTo
         );
@@ -140,7 +140,7 @@ export class CommunicationService implements ICommunicationService {
                 recipientName: staffUser.displayName as string
             }
         }
-        const record = await dispatchMessageForStaffUser(dispatchConfig, templateConfig, Communication);
+        const record = await dispatchMessageForStaffUser(dispatchConfig, templateConfig, Communication, EmailStatus);
         return record;
     }
 
@@ -162,7 +162,7 @@ export class CommunicationService implements ICommunicationService {
             twilioAuthToken,
             twilioFromPhone
         } = this.settings;
-        const { StaffUser, Communication } = this.repositories;
+        const { StaffUser, Communication, EmailStatus } = this.repositories;
         const staffUser = await StaffUser.findOne(serviceRequest.jurisdictionId, serviceRequest.assignedTo);
         const dispatchConfig = {
             channel: 'email',
@@ -185,7 +185,7 @@ export class CommunicationService implements ICommunicationService {
                 recipientName: staffUser.displayName as string
             }
         }
-        const record = await dispatchMessageForStaffUser(dispatchConfig, templateConfig, Communication);
+        const record = await dispatchMessageForStaffUser(dispatchConfig, templateConfig, Communication, EmailStatus);
         return record;
     }
 
@@ -204,7 +204,7 @@ export class CommunicationService implements ICommunicationService {
             twilioAuthToken,
             twilioFromPhone
         } = this.settings;
-        const { Communication, StaffUser } = this.repositories;
+        const { Communication, StaffUser, EmailStatus } = this.repositories;
         const records: CommunicationAttributes[] = [];
         const dispatchConfig = {
             channel: serviceRequest.communicationChannel as string,
@@ -228,7 +228,7 @@ export class CommunicationService implements ICommunicationService {
             }
         }
         const record = await dispatchMessageForPublicUser(
-            serviceRequest, dispatchConfig, templateConfig, Communication
+            serviceRequest, dispatchConfig, templateConfig, Communication, EmailStatus
         );
         records.push(record);
         const [staffUsers, _count] = await StaffUser.findAll(serviceRequest.jurisdictionId);
@@ -255,7 +255,7 @@ export class CommunicationService implements ICommunicationService {
                     recipientName: admin.displayName as string
                 }
             }
-            const record = await dispatchMessageForStaffUser(dispatchConfig, templateConfig, Communication);
+            const record = await dispatchMessageForStaffUser(dispatchConfig, templateConfig, Communication, EmailStatus);
             records.push(record);
         }
         return records;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,7 +4,7 @@ import { json, Router, urlencoded } from 'express';
 import { wrapHandler } from '../helpers';
 import { internalServerError, notFound } from '../middlewares';
 import type { ModelDefinition, PluginBase } from '../types';
-import { CommunicationModel, CommunicationRepository, communicationsRouter, InboundMapModel } from './communications';
+import { ChannelStatusModel, CommunicationModel, CommunicationRepository, communicationsRouter, EmailStatusRepository, InboundEmailRepository, InboundMapModel } from './communications';
 import { DepartmentModel, DepartmentRepository, departmentRouter } from './departments';
 import { JurisdictionModel, JurisdictionRepository, jurisdictionRouter } from './jurisdictions';
 import { open311Router } from './open311';
@@ -37,6 +37,7 @@ const coreModels: ModelDefinition[] = [
     CommunicationModel,
     DepartmentModel,
     InboundMapModel,
+    ChannelStatusModel
 ]
 
 const coreRepositories: PluginBase[] = [
@@ -45,7 +46,10 @@ const coreRepositories: PluginBase[] = [
     ServiceRepository,
     StaffUserRepository,
     CommunicationRepository,
-    DepartmentRepository
+    DepartmentRepository,
+    InboundEmailRepository,
+    EmailStatusRepository,
+
 ]
 
 const coreMiddlewares: RequestHandler[] = [

--- a/src/core/service-requests/models.ts
+++ b/src/core/service-requests/models.ts
@@ -150,14 +150,6 @@ export const ServiceRequestModel: ModelDefinition = {
                 }
             }
         },
-        // if, when communicating, we find out that the email/phone is not valid
-        // then we set to false, if is valid set to true, and, if value is null
-        // then we dont know yet.
-        communicationChannelValid: {
-            type: DataTypes.BOOLEAN,
-            defaultValue: null,
-            allowNull: true,
-        },
         closeDate: {
             allowNull: true,
             type: DataTypes.DATE,

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -27,7 +27,7 @@ function applyCoreModelRelations(models: Models) {
         ServiceRequestComment,
         Communication,
         Department,
-        InboundMap
+        InboundMap,
     } = models;
 
     Jurisdiction.hasMany(StaffUser, { as: 'staffUsers', foreignKey: 'jurisdictionId' });

--- a/src/migrations/14_channel_status.ts
+++ b/src/migrations/14_channel_status.ts
@@ -1,0 +1,47 @@
+import type { QueryInterface } from 'sequelize';
+import { DataTypes } from 'sequelize';
+
+export async function up({ context: queryInterface }: Record<string, QueryInterface>): Promise<void> {
+
+    await queryInterface.createTable('ChannelStatus', {
+        id: { // email or phone
+            type: DataTypes.STRING,
+            primaryKey: true,
+        },
+        channel: {
+            allowNull: false,
+            type: DataTypes.ENUM('email', 'phone'),
+        },
+        status: {
+            type: DataTypes.BOOLEAN,
+            allowNull: true,
+        },
+        statusLog: { // an array of [event, status] ordered new to old
+            type: DataTypes.JSONB,
+            allowNull: false,
+        },
+        createdAt: {
+            allowNull: false,
+            type: DataTypes.DATE
+        },
+        updatedAt: {
+            allowNull: false,
+            type: DataTypes.DATE
+        },
+    });
+    await queryInterface.removeColumn('ServiceRequest', 'communicationChannelValid');
+
+}
+
+export async function down({ context: queryInterface }: Record<string, QueryInterface>): Promise<void> {
+    await queryInterface.dropTable('ChannelStatus');
+    await queryInterface.addColumn(
+        'ServiceRequest',
+        'communicationChannelValid',
+        {
+            type: DataTypes.BOOLEAN,
+            defaultValue: null,
+            allowNull: true,
+        },
+    );
+}

--- a/src/migrations/14_channel_status.ts
+++ b/src/migrations/14_channel_status.ts
@@ -12,11 +12,11 @@ export async function up({ context: queryInterface }: Record<string, QueryInterf
             allowNull: false,
             type: DataTypes.ENUM('email', 'phone'),
         },
-        status: {
+        isAllowed: {
             type: DataTypes.BOOLEAN,
             allowNull: true,
         },
-        statusLog: { // an array of [event, status] ordered new to old
+        log: { // an array of [event, status] ordered new to old
             type: DataTypes.JSONB,
             allowNull: false,
         },

--- a/src/registry/repositories.ts
+++ b/src/registry/repositories.ts
@@ -1,12 +1,12 @@
 import { Container } from 'inversify';
-import { CommunicationRepository, InboundEmailRepository } from '../core/communications';
+import { CommunicationRepository, EmailStatusRepository, InboundEmailRepository } from '../core/communications';
 import { CommunicationService } from '../core/communications/services';
 import { DepartmentRepository } from '../core/departments';
 import { JurisdictionRepository } from '../core/jurisdictions';
 import { ServiceRequestRepository } from '../core/service-requests';
 import { ServiceRepository } from '../core/services';
 import { StaffUserRepository } from '../core/staff-users';
-import type { AppSettings, ICommunicationRepository, ICommunicationService, IDepartmentRepository, IInboundEmailRepository, IJurisdictionRepository, IServiceRepository, IServiceRequestRepository, IStaffUserRepository, Plugin, Services } from '../types';
+import type { AppSettings, ICommunicationRepository, ICommunicationService, IDepartmentRepository, IEmailStatusRepository, IInboundEmailRepository, IJurisdictionRepository, IServiceRepository, IServiceRequestRepository, IStaffUserRepository, Plugin, Services } from '../types';
 import { DatabaseEngine, Models, Repositories } from '../types';
 import { appIds, repositoryIds, serviceIds } from './service-identifiers';
 
@@ -35,6 +35,9 @@ function bindRepositoriesWithPlugins(
     repositoryContainer.bind<IInboundEmailRepository>(repositoryIds.IInboundEmailRepository).to(
         InboundEmailRepository
     );
+    repositoryContainer.bind<IEmailStatusRepository>(repositoryIds.IEmailStatusRepository).to(
+        EmailStatusRepository
+    );
     repositoryContainer.bind<IDepartmentRepository>(repositoryIds.IDepartmentRepository).to(
         DepartmentRepository
     );
@@ -53,6 +56,7 @@ function bindRepositoriesWithPlugins(
     );
     const Communication = repositoryContainer.get<ICommunicationRepository>(repositoryIds.ICommunicationRepository);
     const InboundEmail = repositoryContainer.get<IInboundEmailRepository>(repositoryIds.IInboundEmailRepository);
+    const EmailStatus = repositoryContainer.get<IEmailStatusRepository>(repositoryIds.IEmailStatusRepository);
     const Department = repositoryContainer.get<IDepartmentRepository>(repositoryIds.IDepartmentRepository);
 
     const repositories = {
@@ -62,6 +66,7 @@ function bindRepositoriesWithPlugins(
         ServiceRequest,
         Communication,
         InboundEmail,
+        EmailStatus,
         Department
     }
     return repositories;

--- a/src/registry/service-identifiers.ts
+++ b/src/registry/service-identifiers.ts
@@ -6,6 +6,7 @@ export const repositoryIds = {
     IEventRepository: Symbol('IEventRepository'),
     ICommunicationRepository: Symbol('ICommunicationRepository'),
     IInboundEmailRepository: Symbol('IInboundEmailRepository'),
+    IEmailStatusRepository: Symbol('IEmailStatusRepository'),
     IDepartmentRepository: Symbol('IDepartmentRepository'),
 };
 

--- a/src/tools/fake-data-generator.ts
+++ b/src/tools/fake-data-generator.ts
@@ -128,7 +128,7 @@ function makeInboundMap(options: Partial<TestDataMakerOptions>) {
     } as InboundMapAttributes
 }
 
-function makeChannelStatus(options: Partial<TestDataMakerOptions>) {
+function makeChannelStatus() {
     const statuses = [
         ['delivered', true],
         ['group_resubscribe', true],

--- a/src/tools/fake-data-generator.ts
+++ b/src/tools/fake-data-generator.ts
@@ -2,7 +2,7 @@ import faker from 'faker';
 import type { Sequelize } from 'sequelize/types';
 import { REQUEST_STATUS_KEYS } from '../core/service-requests';
 import { STAFF_USER_PERMISSIONS } from '../core/staff-users';
-import { CommunicationAttributes, DepartmentAttributes, InboundMapAttributes, JurisdictionAttributes, ServiceAttributes, ServiceRequestAttributes, ServiceRequestCommentAttributes, ServiceRequestInstance, StaffUserAttributes, TestDataMakerOptions, TestDataPayload } from '../types';
+import { ChannelStatusAttributes, CommunicationAttributes, DepartmentAttributes, InboundMapAttributes, JurisdictionAttributes, ServiceAttributes, ServiceRequestAttributes, ServiceRequestCommentAttributes, ServiceRequestInstance, StaffUserAttributes, TestDataMakerOptions, TestDataPayload } from '../types';
 
 /* eslint-disable */
 function factory(generator: Function, times: number, generatorOpts: {}) {
@@ -128,6 +128,31 @@ function makeInboundMap(options: Partial<TestDataMakerOptions>) {
     } as InboundMapAttributes
 }
 
+function makeChannelStatus(options: Partial<TestDataMakerOptions>) {
+    const statuses = [
+        ['delivered', true],
+        ['group_resubscribe', true],
+        ['blocked', false],
+        ['dropped', false],
+        ['processed', null],
+        ['open', null],
+    ];
+    const statusGenerator = faker.helpers.randomize(statuses);
+    const email = {
+        id: faker.internet.email(),
+        channel: 'email',
+        status: statusGenerator[1],
+        statusLog: [statusGenerator]
+    };
+    const phone = {
+        id: faker.phone.phoneNumber(),
+        channel: 'phone',
+        status: statusGenerator[1],
+        statusLog: [statusGenerator]
+    };
+    return faker.helpers.randomize([email, phone]) as ChannelStatusAttributes
+}
+
 export async function writeTestDataToDatabase(databaseEngine: Sequelize, testData: TestDataPayload): Promise<void> {
     const {
         Jurisdiction,
@@ -137,7 +162,8 @@ export async function writeTestDataToDatabase(databaseEngine: Sequelize, testDat
         ServiceRequestComment,
         Communication,
         Department,
-        InboundMap
+        InboundMap,
+        ChannelStatus
     } = databaseEngine.models;
 
     for (const jurisdictionData of testData.jurisdictions) {
@@ -171,6 +197,10 @@ export async function writeTestDataToDatabase(databaseEngine: Sequelize, testDat
         await InboundMap.create(inboundMapData);
     }
 
+    for (const channelStatusData of testData.channelStatuses) {
+        await ChannelStatus.create(channelStatusData);
+    }
+
 }
 
 export default function makeTestData(): TestDataPayload {
@@ -181,6 +211,7 @@ export default function makeTestData(): TestDataPayload {
     let communications: CommunicationAttributes[] = [];
     let departments: DepartmentAttributes[] = [];
     let inboundMaps: InboundMapAttributes[] = [];
+    let channelStatuses: ChannelStatusAttributes[] = [];
 
     for (const jurisdiction of jurisdictions) {
         staffUsers = staffUsers.concat(
@@ -208,6 +239,8 @@ export default function makeTestData(): TestDataPayload {
         )
     }
 
+    channelStatuses = factory(makeChannelStatus, 100, {}) as unknown as ChannelStatusAttributes[];
+
     return {
         jurisdictions,
         staffUsers,
@@ -215,6 +248,7 @@ export default function makeTestData(): TestDataPayload {
         serviceRequests,
         communications,
         departments,
-        inboundMaps
+        inboundMaps,
+        channelStatuses
     }
 }

--- a/src/tools/fake-data-generator.ts
+++ b/src/tools/fake-data-generator.ts
@@ -141,14 +141,14 @@ function makeChannelStatus() {
     const email = {
         id: faker.internet.email(),
         channel: 'email',
-        status: statusGenerator[1],
-        statusLog: [statusGenerator]
+        isAllowed: statusGenerator[1],
+        log: [statusGenerator]
     };
     const phone = {
         id: faker.phone.phoneNumber(),
         channel: 'phone',
-        status: statusGenerator[1],
-        statusLog: [statusGenerator]
+        isAllowed: statusGenerator[1],
+        log: [statusGenerator]
     };
     return faker.helpers.randomize([email, phone]) as ChannelStatusAttributes
 }

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -257,13 +257,13 @@ export interface EmailEventAttributes {
     type?: string;
 }
 
-export type StatusLogEntry = [string, boolean | null | undefined];
+export type LogEntry = [string, boolean | null | undefined];
 
 export interface ChannelStatusAttributes {
     id: string;
     channel: string;
-    status: boolean | null | undefined;
-    statusLog: StatusLogEntry[];
+    isAllowed: boolean | null;
+    log: LogEntry[];
 }
 
 export type ChannelStatusCreateAttributes = Partial<ChannelStatusAttributes>

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -202,6 +202,7 @@ export interface TestDataPayload {
     communications: CommunicationAttributes[];
     departments: DepartmentAttributes[];
     inboundMaps: InboundMapAttributes[];
+    channelStatuses: ChannelStatusAttributes[];
 }
 
 export interface TestDataMakerOptions {
@@ -244,3 +245,28 @@ export interface InboundEmailDataToRequestAttributes {
 }
 
 export type PublicId = string | undefined;
+
+export interface EmailEventAttributes {
+    email: string;
+    event: string;
+    timestamp: number;
+    'smtp-id': string;
+    category: string | [];
+    sg_event_id?: string;
+    sg_message_id?: string;
+    type?: string;
+}
+
+export type StatusLogEntry = [string, boolean | null | undefined];
+
+export interface ChannelStatusAttributes {
+    id: string;
+    channel: string;
+    status: boolean | null | undefined;
+    statusLog: StatusLogEntry[];
+}
+
+export type ChannelStatusCreateAttributes = Partial<ChannelStatusAttributes>
+
+export interface ChannelStatusInstance
+    extends Model<ChannelStatusAttributes, ChannelStatusCreateAttributes>, ChannelStatusAttributes { }

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,7 +1,7 @@
 import { Model, ModelAttributes, ModelCtor, ModelOptions, QueryInterface, Sequelize } from "sequelize/types";
 import { Umzug } from "umzug";
 import { CommunicationAttributes, CommunicationCreateAttributes, DepartmentAttributes, DepartmentCreateAttributes, JurisdictionAttributes, JurisdictionCreateAttributes, ServiceAttributes, ServiceCreateAttributes, ServiceRequestAttributes, ServiceRequestCommentAttributes, ServiceRequestCommentCreateAttributes, ServiceRequestCreateAttributes, StaffUserAttributes, StaffUserCreateAttributes } from ".";
-import { InboundMapAttributes, InboundMapCreateAttributes } from "./data";
+import { ChannelStatusAttributes, ChannelStatusCreateAttributes, InboundMapAttributes, InboundMapCreateAttributes } from "./data";
 
 export type DatabaseEngine = Sequelize;
 export type MigrationEngine = Umzug<QueryInterface>;
@@ -36,6 +36,8 @@ export type ServiceRequestModel = ModelCtor<Model<ServiceRequestAttributes, Serv
 
 export type InboundMapModel = ModelCtor<Model<InboundMapAttributes, InboundMapCreateAttributes>>;
 
+export type IChannelStatusModel = ModelCtor<Model<ChannelStatusAttributes, ChannelStatusCreateAttributes>>;
+
 export interface Models {
     Jurisdiction: ModelCtor<Model<JurisdictionAttributes, JurisdictionCreateAttributes>>;
     StaffUser: ModelCtor<Model<StaffUserAttributes, StaffUserCreateAttributes>>;
@@ -45,4 +47,5 @@ export interface Models {
     Communication: ModelCtor<Model<CommunicationAttributes, CommunicationCreateAttributes>>;
     Department: ModelCtor<Model<DepartmentAttributes, DepartmentCreateAttributes>>;
     InboundMap: InboundMapModel;
+    ChannelStatus: IChannelStatusModel;
 }

--- a/src/types/repositories.ts
+++ b/src/types/repositories.ts
@@ -12,7 +12,7 @@ import type {
     StaffUserAttributes,
     StaffUserLookUpAttributes
 } from '.';
-import { InboundMapAttributes } from './data';
+import { ChannelStatusAttributes, ChannelStatusInstance, EmailEventAttributes, InboundMapAttributes } from './data';
 
 export interface RepositoryBase extends PluginBase {
     models: Models;
@@ -92,6 +92,14 @@ export interface IInboundEmailRepository extends RepositoryBase {
     createMap: (data: InboundMapAttributes) => Promise<InboundMapAttributes>;
 }
 
+export interface IEmailStatusRepository extends RepositoryBase {
+    create: (data: ChannelStatusAttributes) =>
+        Promise<ChannelStatusInstance>;
+    createFromEvent: (data: EmailEventAttributes) =>
+        Promise<ChannelStatusInstance>;
+    findOne: (email: string) => Promise<ChannelStatusInstance>;
+}
+
 export interface Repositories {
     Jurisdiction: IJurisdictionRepository;
     StaffUser: IStaffUserRepository;
@@ -100,4 +108,5 @@ export interface Repositories {
     Communication: ICommunicationRepository;
     InboundEmail: IInboundEmailRepository;
     Department: IDepartmentRepository;
+    EmailStatus: IEmailStatusRepository;
 }

--- a/test/fixtures/event-email.ts
+++ b/test/fixtures/event-email.ts
@@ -1,0 +1,126 @@
+import { EmailEventAttributes } from "../../src/types";
+
+export const emailEvent = [
+    {
+        "email": "example@test.com",
+        "timestamp": 1513299569,
+        "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+        "event": "processed",
+        "category": "cat facts",
+        "sg_event_id": "sg_event_id",
+        "sg_message_id": "sg_message_id"
+    },
+    {
+        "email": "example@test.com",
+        "timestamp": 1513299569,
+        "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+        "event": "deferred",
+        "ip": "168.1.1.1",
+        "category": "cat facts",
+        "sg_event_id": "sg_event_id",
+        "sg_message_id": "sg_message_id",
+        "response": "400 try again later",
+        "attempt": "5"
+    },
+    {
+        "email": "example@test.com",
+        "timestamp": 1513299569,
+        "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+        "event": "delivered",
+        "ip": "168.1.1.1",
+        "category": "cat facts",
+        "sg_event_id": "sg_event_id",
+        "sg_message_id": "sg_message_id",
+        "response": "250 OK"
+    },
+    {
+        "email": "example@test.com",
+        "timestamp": 1513299569,
+        "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+        "event": "open",
+        "sg_machine_open": false,
+        "category": "cat facts",
+        "sg_event_id": "sg_event_id",
+        "sg_message_id": "sg_message_id",
+        "useragent": "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
+        "ip": "255.255.255.255"
+    },
+    {
+        "email": "example@test.com",
+        "timestamp": 1513299569,
+        "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+        "event": "click",
+        "category": "cat facts",
+        "sg_event_id": "sg_event_id",
+        "sg_message_id": "sg_message_id",
+        "useragent": "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
+        "ip": "255.255.255.255",
+        "url": "http://www.sendgrid.com/"
+    },
+    {
+        "email": "example@test.com",
+        "timestamp": 1513299569,
+        "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+        "event": "bounce",
+        "ip": "168.1.1.1",
+        "category": "cat facts",
+        "sg_event_id": "sg_event_id",
+        "sg_message_id": "sg_message_id",
+        "reason": "500 unknown recipient",
+        "status": "5.0.0"
+    },
+    {
+        "email": "example@test.com",
+        "timestamp": 1513299569,
+        "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+        "event": "dropped",
+        "category": "cat facts",
+        "sg_event_id": "sg_event_id",
+        "sg_message_id": "sg_message_id",
+        "reason": "Bounced Address",
+        "status": "5.0.0"
+    },
+    {
+        "email": "example@test.com",
+        "timestamp": 1513299569,
+        "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+        "event": "spamreport",
+        "sg_event_id": "sg_event_id",
+        "sg_message_id": "sg_message_id"
+    },
+    {
+        "email": "example@test.com",
+        "timestamp": 1513299569,
+        "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+        "event": "unsubscribe",
+        "category": "cat facts",
+        "sg_event_id": "sg_event_id",
+        "sg_message_id": "sg_message_id"
+    },
+    {
+        "email": "example@test.com",
+        "timestamp": 1513299569,
+        "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+        "event": "group_unsubscribe",
+        "category": "cat facts",
+        "sg_event_id": "sg_event_id",
+        "sg_message_id": "sg_message_id",
+        "useragent": "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
+        "ip": "255.255.255.255",
+        "url": "http://www.sendgrid.com/",
+        "asm_group_id": 10
+    },
+    {
+        "email": "example@test.com",
+        "timestamp": 1513299569,
+        "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+        "event": "group_resubscribe",
+        "category": "cat facts",
+        "sg_event_id": "sg_event_id",
+        "sg_message_id": "sg_message_id",
+        "useragent": "Mozilla/4.0 (compatible; MSIE 6.1; Windows XP; .NET CLR 1.1.4322; .NET CLR 2.0.50727)",
+        "ip": "000.000.000.000",
+        "url": "http://www.sendgrid.com/",
+        "asm_group_id": 10
+    }
+] as unknown as EmailEventAttributes[]

--- a/test/test-communications.ts
+++ b/test/test-communications.ts
@@ -70,7 +70,7 @@ describe('Verify Core Communications Functionality.', function () {
     });
 
     it('dispatch a message for a public user', async function () {
-        const { ServiceRequest, Communication } = app.repositories;
+        const { ServiceRequest, Communication, EmailStatus } = app.repositories;
         const {
             sendGridApiKey,
             sendGridFromEmail,
@@ -107,13 +107,13 @@ describe('Verify Core Communications Functionality.', function () {
             }
         }
         const record = await dispatchMessageForPublicUser(
-            serviceRequest, dispatchConfig, templateConfig, Communication
+            serviceRequest, dispatchConfig, templateConfig, Communication, EmailStatus
         );
         chai.assert(record);
     });
 
     it('dispatch a message for a staff user', async function () {
-        const { StaffUser, Communication } = app.repositories;
+        const { StaffUser, Communication, EmailStatus } = app.repositories;
         const {
             sendGridApiKey,
             sendGridFromEmail,
@@ -151,7 +151,7 @@ describe('Verify Core Communications Functionality.', function () {
             }
         }
         const record = await dispatchMessageForStaffUser(
-            dispatchConfig, templateConfig, Communication
+            dispatchConfig, templateConfig, Communication, EmailStatus
         );
         chai.assert(record);
     });

--- a/test/test-models.ts
+++ b/test/test-models.ts
@@ -88,8 +88,16 @@ describe('Verify Core Models.', function () {
 
     it('should write inbound maps to database', async function () {
         const { InboundMap } = app.database.models;
-        for (const InboundMapData of testData.inboundMaps) {
-            const record = await InboundMap.create(InboundMapData);
+        for (const inboundMapData of testData.inboundMaps) {
+            const record = await InboundMap.create(inboundMapData);
+            chai.assert(record);
+        }
+    });
+
+    it('should write channel statuses to database', async function () {
+        const { ChannelStatus } = app.database.models;
+        for (const channelStatusData of testData.channelStatuses) {
+            const record = await ChannelStatus.create(channelStatusData);
             chai.assert(record);
         }
     });

--- a/test/test-repositories.ts
+++ b/test/test-repositories.ts
@@ -7,6 +7,7 @@ import { STAFF_USER_PERMISSIONS } from '../src/core/staff-users/models';
 import { createApp } from '../src/index';
 import makeTestData from '../src/tools/fake-data-generator';
 import { TestDataPayload } from '../src/types';
+import { emailEvent } from './fixtures/event-email';
 
 describe('Verify Core Repositories.', function () {
 
@@ -388,4 +389,31 @@ describe('Verify Core Repositories.', function () {
         }
     });
 
+    it('should write email channel statuses from email events via repository', async function () {
+        const { EmailStatus } = app.repositories;
+        for (const event of emailEvent) {
+            const record = await EmailStatus.createFromEvent(event);
+            chai.assert(record);
+        }
+    });
+
+    it('should write email channel statuses via repository', async function () {
+        const { EmailStatus } = app.repositories;
+        for (const status of testData.channelStatuses) {
+            const record = await EmailStatus.create(status);
+            chai.assert(record);
+        }
+    });
+
+    it('should get an email channel status via repository', async function () {
+        const { EmailStatus } = app.repositories;
+        const emailStatuses = _.filter(testData.channelStatuses, { channel: 'email' });
+        for (const status of emailStatuses) {
+            const record = await EmailStatus.findOne(status.id);
+            chai.assert(record);
+            chai.assert.equal(record.id, status.id);
+            chai.assert.equal(record.status, status.status);
+            chai.assert.equal(record.statusLog[0][0], status.statusLog[0][0]);
+        }
+    });
 });

--- a/test/test-repositories.ts
+++ b/test/test-repositories.ts
@@ -412,8 +412,8 @@ describe('Verify Core Repositories.', function () {
             const record = await EmailStatus.findOne(status.id);
             chai.assert(record);
             chai.assert.equal(record.id, status.id);
-            chai.assert.equal(record.status, status.status);
-            chai.assert.equal(record.statusLog[0][0], status.statusLog[0][0]);
+            chai.assert.equal(record.isAllowed, status.isAllowed);
+            chai.assert.equal(record.log[0][0], status.log[0][0]);
         }
     });
 });


### PR DESCRIPTION
This pull requests enables GovFlow to "know" delivery status of email.

We integrate with SendGrid events webhook and, based on the information we receive, we maintain a table of current status (and a log of status changes, if any) for a given email address, where:

- `null` means we don't know yet if it can accept deliveries, so we continue to treat it as if it can
- `true` means it can accept deliveries
- `false` means it can't accept deliveries

Different event labels from SendGrid are mapped to these values. The original event values from SendGrid, and our mapping, are also available on the `statusLog` attribute of the `ChannelStatus` table that records this information. This attribute is an array of pairs, ordered from newest to oldest, like:

`[['unsubscribe', false], ['delivered', true], ['processing', null]]` 

The dispatchMessage function in GovFlow checks an email's status before allowing an email to be sent to it. This is a "last minute" safety mechanism for API consumers, and also the verification point for automated dispatch (ie transaction email that is event-driven from data mutations in the application). Ideally, API consumers will check if an email is valid for sending communications via a new endpoint `communications/status/email/${email}`, where `email` is a url encoded base 64 representation of the email address.