### PR TITLE
generate inbound maps for service requests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "send-test-email": "ts-node ./src/cli/send-test-email",
     "send-test-sms": "ts-node ./src/cli/send-test-sms",
     "send-test-dispatch": "ts-node ./src/cli/send-test-dispatch",
-    "ensure-public-ids": "ts-node ./src/cli/ensure-public-ids"
+    "ensure-public-ids": "ts-node ./src/cli/ensure-public-ids",
+    "ensure-service-request-inbound-map": "ts-node ./src/cli/ensure-service-request-inbound-map"
   },
   "bin": {
     "govflow-start": "./cli/default-server.js",
@@ -23,7 +24,8 @@
     "govflow-send-test-email": "./cli/send-test-email.js",
     "govflow-send-test-sms": "./cli/send-test-sms.js",
     "govflow-send-test-dispatch": "./cli/send-test-dispatch.js",
-    "govflow-ensure-public-ids": "./cli/ensure-public-ids.js"
+    "govflow-ensure-public-ids": "./cli/ensure-public-ids.js",
+    "govflow-service-request-inbound-map": "./cli/ensure-service-request-inbound-map.js"
   },
   "license": "MIT",
   "dependencies": {

--- a/src/cli/ensure-service-request-inbound-map.ts
+++ b/src/cli/ensure-service-request-inbound-map.ts
@@ -1,0 +1,13 @@
+#! /usr/bin/env node
+import { createApp } from '..';
+import { ServiceRequestInstance } from '../types';
+
+(async () => {
+    const app = await createApp();
+    const { database } = app;
+    const { ServiceRequest, InboundMap } = database.models;
+    const records = await ServiceRequest.findAll() as ServiceRequestInstance[];
+    for (const record of records) {
+        await InboundMap.create({ id: record.id })
+    }
+})();

--- a/src/core/communications/helpers.ts
+++ b/src/core/communications/helpers.ts
@@ -243,7 +243,9 @@ export async function extractServiceRequestfromInboundEmail(data: InboundEmailDa
     const { subject, to, cc, bcc, from, text, headers } = data;
     const toEmail = extractToEmail(inboundEmailDomain, headers, to, cc, bcc);
     const fromEmail = extractFromEmail(from);
-    const { jurisdictionId, departmentId, staffUserId, serviceRequestId, serviceId } = await findIdentifiers(toEmail, InboundMap);
+    const { jurisdictionId, departmentId, staffUserId, serviceRequestId, serviceId } = await findIdentifiers(
+        toEmail, InboundMap
+    );
     const description = extractDescriptionFromInboundEmail(subject, text);
     const publicId = extractPublicIdFromInboundEmail(subject);
     const extractCreatedAt = extractCreatedAtFromInboundEmail(headers);
@@ -255,7 +257,20 @@ export async function extractServiceRequestfromInboundEmail(data: InboundEmailDa
         email = fromEmail.address || ''
     }
     return [
-        { jurisdictionId, departmentId, assignedTo: staffUserId, serviceRequestId, serviceId, firstName, lastName, email, description, inputChannel, createdAt }, publicId
+        {
+            jurisdictionId,
+            departmentId,
+            assignedTo: staffUserId,
+            serviceRequestId,
+            serviceId,
+            firstName,
+            lastName,
+            email,
+            description,
+            inputChannel,
+            createdAt
+        },
+        publicId
     ];
 }
 

--- a/src/core/communications/helpers.ts
+++ b/src/core/communications/helpers.ts
@@ -243,7 +243,7 @@ export async function extractServiceRequestfromInboundEmail(data: InboundEmailDa
     const { subject, to, cc, bcc, from, text, headers } = data;
     const toEmail = extractToEmail(inboundEmailDomain, headers, to, cc, bcc);
     const fromEmail = extractFromEmail(from);
-    const { jurisdictionId, departmentId } = await findIdentifiers(toEmail, InboundMap);
+    const { jurisdictionId, departmentId, staffUserId, serviceRequestId, serviceId } = await findIdentifiers(toEmail, InboundMap);
     const description = extractDescriptionFromInboundEmail(subject, text);
     const publicId = extractPublicIdFromInboundEmail(subject);
     const extractCreatedAt = extractCreatedAtFromInboundEmail(headers);
@@ -255,7 +255,7 @@ export async function extractServiceRequestfromInboundEmail(data: InboundEmailDa
         email = fromEmail.address || ''
     }
     return [
-        { jurisdictionId, departmentId, firstName, lastName, email, description, inputChannel, createdAt }, publicId
+        { jurisdictionId, departmentId, assignedTo: staffUserId, serviceRequestId, serviceId, firstName, lastName, email, description, inputChannel, createdAt }, publicId
     ];
 }
 

--- a/src/core/communications/models.ts
+++ b/src/core/communications/models.ts
@@ -106,6 +106,10 @@ export const InboundMapModel: ModelDefinition = {
             allowNull: false,
             primaryKey: true,
         },
+        staffUserId: { // is not a foreignKey as commonly customised
+            type: DataTypes.STRING,
+            allowNull: true,
+        }
     },
     options: {
         freezeTableName: true,
@@ -113,6 +117,26 @@ export const InboundMapModel: ModelDefinition = {
             {
                 unique: true,
                 fields: ['id', 'jurisdictionId', 'departmentId']
+            },
+            {
+                unique: true,
+                fields: ['id', 'jurisdictionId', 'departmentId', 'staffUserId']
+            },
+            {
+                unique: true,
+                fields: ['id', 'jurisdictionId', 'departmentId', 'serviceId']
+            },
+            {
+                unique: true,
+                fields: ['id', 'jurisdictionId', 'staffUserId']
+            },
+            {
+                unique: true,
+                fields: ['id', 'jurisdictionId', 'serviceId']
+            },
+            {
+                unique: true,
+                fields: ['id', 'jurisdictionId', 'serviceRequestId']
             }
         ]
     }

--- a/src/core/communications/repositories.ts
+++ b/src/core/communications/repositories.ts
@@ -84,7 +84,9 @@ export class InboundEmailRepository implements IInboundEmailRepository {
             } else {
                 params = Object.assign({}, params, { publicId });
             }
-            const existingRequest = await ServiceRequest.findOne({ where: params }) as unknown as ServiceRequestInstance;
+            const existingRequest = await ServiceRequest.findOne(
+                { where: params }
+            ) as unknown as ServiceRequestInstance;
             const canComment = canSubmitterComment(cleanedData.email, [...staffEmails, existingRequest.email]);
             if (canComment && existingRequest) {
                 const comment = { comment: cleanedData.description, serviceRequestId: existingRequest.id };

--- a/src/core/service-requests/repositories.ts
+++ b/src/core/service-requests/repositories.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import sequelize from 'sequelize';
 import { queryParamsToSequelize } from '../../helpers';
 import { appIds } from '../../registry/service-identifiers';
-import type { AppSettings, IServiceRequestRepository, Models, QueryParamsAll, ServiceRequestAttributes, ServiceRequestCommentAttributes, ServiceRequestCommentCreateAttributes, ServiceRequestCommentInstance, ServiceRequestInstance, ServiceRequestStatusAttributes, StaffUserAttributes } from '../../types';
+import type { AppSettings, InboundMapInstance, IServiceRequestRepository, Models, QueryParamsAll, ServiceRequestAttributes, ServiceRequestCommentAttributes, ServiceRequestCommentCreateAttributes, ServiceRequestCommentInstance, ServiceRequestInstance, ServiceRequestStatusAttributes, StaffUserAttributes } from '../../types';
 import { makeAuditMessage } from './helpers';
 import { REQUEST_STATUSES } from './models';
 
@@ -24,8 +24,10 @@ export class ServiceRequestRepository implements IServiceRequestRepository {
     }
 
     async create(data: Partial<ServiceRequestAttributes>): Promise<ServiceRequestAttributes> {
-        const { ServiceRequest } = this.models;
+        const { ServiceRequest, InboundMap } = this.models;
         const record = await ServiceRequest.create(data) as ServiceRequestInstance;
+        // ensure we have an inbound routing email
+        await InboundMap.create({ id: record.id }) as InboundMapInstance;
         return record;
     }
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -66,6 +66,15 @@ function applyCoreModelRelations(models: Models) {
 
     Department.hasMany(InboundMap, { as: 'inboundMaps', foreignKey: 'departmentId' });
     InboundMap.belongsTo(Department, { as: 'department' });
+
+    // StaffUser.hasMany(InboundMap, { as: 'inboundMaps', foreignKey: 'staffUserId' });
+    // InboundMap.belongsTo(StaffUser, { as: 'staffUser' });
+
+    Service.hasMany(InboundMap, { as: 'inboundMaps', foreignKey: 'serviceId' });
+    InboundMap.belongsTo(Service, { as: 'service' });
+
+    ServiceRequest.hasMany(InboundMap, { as: 'inboundMaps', foreignKey: 'serviceRequestId' });
+    InboundMap.belongsTo(ServiceRequest, { as: 'serviceRequest' });
 }
 
 function registerModels(

--- a/src/migrations/15_inbound_map_entities.ts
+++ b/src/migrations/15_inbound_map_entities.ts
@@ -1,0 +1,36 @@
+import type { QueryInterface } from 'sequelize';
+import { DataTypes } from 'sequelize';
+
+export async function up({ context: queryInterface }: Record<string, QueryInterface>): Promise<void> {
+    await queryInterface.addColumn('InboundMap', 'staffUserId', {
+        type: DataTypes.STRING,
+        allowNull: true,
+    });
+    await queryInterface.addColumn('InboundMap', 'serviceRequestId', {
+        type: DataTypes.UUID,
+        onDelete: 'SET NULL',
+        references: {
+            model: 'ServiceRequest',
+            key: 'id',
+        }
+    });
+    await queryInterface.addColumn('InboundMap', 'serviceId', {
+        type: DataTypes.STRING,
+        onDelete: 'SET NULL',
+        references: {
+            model: 'Service',
+            key: 'id',
+        }
+    });
+    await queryInterface.addIndex('InboundMap', ['id', 'jurisdictionId', 'departmentId', 'staffUserId']);
+    await queryInterface.addIndex('InboundMap', ['id', 'jurisdictionId', 'departmentId', 'serviceId']);
+    await queryInterface.addIndex('InboundMap', ['id', 'jurisdictionId', 'staffUserId']);
+    await queryInterface.addIndex('InboundMap', ['id', 'jurisdictionId', 'serviceId']);
+    await queryInterface.addIndex('InboundMap', ['id', 'jurisdictionId', 'serviceRequestId']);
+}
+
+export async function down({ context: queryInterface }: Record<string, QueryInterface>): Promise<void> {
+    await queryInterface.removeColumn('InboundMap', 'serviceRequestId');
+    await queryInterface.removeColumn('InboundMap', 'serviceId');
+    await queryInterface.removeColumn('InboundMap', 'staffUserId');
+}

--- a/src/tools/fake-data-generator.ts
+++ b/src/tools/fake-data-generator.ts
@@ -125,6 +125,9 @@ function makeInboundMap(options: Partial<TestDataMakerOptions>) {
         id: faker.datatype.uuid(),
         jurisdictionId: options.jurisdiction?.id,
         departmentId: faker.helpers.randomize(options.departments as DepartmentAttributes[]).id,
+        serviceRequestId: faker.helpers.randomize(options.serviceRequests as ServiceRequestAttributes[]).id,
+        serviceId: faker.helpers.randomize(options.services as ServiceAttributes[]).id,
+        staffUserId: faker.helpers.randomize(options.staffUsers as StaffUserAttributes[]).id,
     } as InboundMapAttributes
 }
 

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -86,6 +86,9 @@ export interface ParsedServiceRequestAttributes {
     description: string;
     createdAt: Date | undefined;
     departmentId?: string;
+    assignedTo?: string;
+    serviceRequestId?: string;
+    serviceId?: string;
 }
 
 export interface ServiceRequestInstance
@@ -143,6 +146,9 @@ export interface InboundMapAttributes {
     id: string;
     jurisdictionId: string;
     departmentId?: string;
+    staffUserId?: string;
+    serviceRequestId?: string;
+    serviceId?: string;
 }
 
 export type InboundMapCreateAttributes = Partial<InboundMapAttributes>


### PR DESCRIPTION
When we support two way communication via email, we need a reply to so that valid participants (submitters and staff) can email directly into a service request thread. This PR ensures that service requests always have an inbound map record to facilitate that. It also ships with a script to create such records on databases where there are existing service requests which will not have such records.